### PR TITLE
Add notes about configuring MQTT in config.g

### DIFF
--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -162,3 +162,42 @@ The following message will be printed by the `echo` client.
 ```
 echo: recieved will message with topic 'topic-will': b'message-will'
 ```
+
+# MQTT Configuration in `config.g`
+
+The MQTT client configuration commands (`M586.4`) and MQTT protocol enabling command (`M586 P4`)
+can be executed from `config.g`. It is recommended to execute the `M586.4` commands first before
+`M586 P4`.
+
+Using the credentials in this demonstrations for example, the following snippet can be
+added to the `config.g`.
+
+```
+; Configure MQTT client
+M586.4 C"duet" ; client name
+M586.4 U"mqtt-duet" K"mqtt-duet-pswd" ; username and password
+M586.4 S"topic-echo" ; subscription topic
+M586.4 W"message-will" T"topic-will" R0 ; will topic and message
+; Enable MQTT protocol
+M586 P4 H192.168.111.1 S1
+```
+
+## On Versions Prior to RepRapFirmware 3.5.2
+
+On RepRapFirmware versions prior to 3.5.2, configuring MQTT in `config.g` does not work.
+The workaround is to instead do the configuration on `daemon.g`, with a little bit of additional
+logic to only run it once:
+
+```
+if !exists(global.mqttInited)
+    ; Configure MQTT client
+    M586.4 C"duet" ; client name
+    M586.4 U"mqtt-duet" K"mqtt-duet-pswd" ; username and password
+    M586.4 S"topic-echo" ; subscription topic
+    M586.4 W"message-will" T"topic-will" R0 ; will topic and message
+    ; Enable MQTT protocol
+    M586 P4 H192.168.111.1 S1
+    ; Since daemon.g runs repeatedly, use a variable to only run
+    ; MQTT client configuration once; see first line.
+    global mqttInited = true
+```

--- a/mqtt/echo.py
+++ b/mqtt/echo.py
@@ -1,6 +1,7 @@
 # Runs the MQTT broker and echo client. See README.md for more information
 # about the demonstration this Python script is a part of.
 
+import paho.mqtt
 import paho.mqtt.client as mqtt
 import subprocess
 
@@ -64,7 +65,11 @@ def on_message(client, userdata, msg):
         print(f"{Fore.YELLOW}echo: recieved message with topic '{msg.topic}': {msg.payload} {Style.RESET_ALL}")
 
 def main():
-    client = mqtt.Client(CLIENT_ID)
+    if paho.mqtt.__version__[0] > '1':
+        client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, CLIENT_ID)
+    else:
+        client = mqtt.Client(CLIENT_ID)
+
     client.username_pw_set(USERNAME, PASSWORD)
 
     client.on_connect = on_connect


### PR DESCRIPTION
- Add notes about configuring MQTT in config.g, and on versions prior to 3.5.2, the workaround.
- Make echo.py compatible with new paho-mqtt version